### PR TITLE
♻️refactor: page/ShopDetail Link 연결 및 함수추가

### DIFF
--- a/src/components/ShopDetail/NoticesCardList.tsx
+++ b/src/components/ShopDetail/NoticesCardList.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+import removePrefix from '@/lib/utils/RemovePrefix';
 import { Item3, Shops } from '@/types/ShopDetail';
 import PostCard from '../Post/PostCard';
 
@@ -19,13 +21,14 @@ export default function NoticesCardList({
       </h1>
       <div className="flex gap-32px">
         <div className="grid grid-cols-2 gap-x-8px gap-y-12px my-0 mx-auto pc:gap-x-36px pc:gap-y-26px pc:grid-cols-3">
-          {noticesData.map((item) => (
-            <PostCard
-              key={item.item.id}
-              noticeData={item.item}
-              shopData={shopData}
-            />
-          ))}
+          {noticesData.map((item) => {
+            const link = removePrefix(item.links[0].href);
+            return (
+              <Link key={item.item.id} href={link}>
+                <PostCard noticeData={item.item} shopData={shopData} />
+              </Link>
+            );
+          })}
         </div>
       </div>
     </>

--- a/src/lib/utils/RemovePrefix.ts
+++ b/src/lib/utils/RemovePrefix.ts
@@ -1,0 +1,7 @@
+export default function removePrefix(url: string): string {
+  const prefix = '/api/6-12/the-julge';
+  if (url.startsWith(prefix)) {
+    return url.slice(prefix.length);
+  }
+  return url;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> DD-31

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/sprint6-team12/the-julge/assets/162148781/4a219e67-e84b-42ae-87b4-62cddf8b30b4)

가게 공고 조회시 오는 데이터의 첫번째 links의 href를 활용해서 앞에 주소를 삭제한 데이터를 link의 href로 전달했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
