### PR TITLE
refactor: table-connect-to-the-api

### DIFF
--- a/src/components/Badge/StatusBadge.tsx
+++ b/src/components/Badge/StatusBadge.tsx
@@ -1,6 +1,6 @@
 import { STATUS_MAP } from '@/constants/statusMap';
 
-type Status = 'pending' | 'accepted' | 'rejected';
+type Status = 'pending' | 'accepted' | 'rejected' | 'canceled';
 interface StatusBadgeProps {
   status: Status;
 }

--- a/src/components/Table/EmployeeTable.tsx
+++ b/src/components/Table/EmployeeTable.tsx
@@ -1,48 +1,70 @@
-function EmployeeTable() {
-  //임시데이터
-  const mockData = [
-    {
-      id: 1,
-      shopName: 'HS 과일주스',
-      startsAt: '2023-01-12 10:00 ~ 12:00',
-      hourlyPay: '15,000원',
-      supportStatus: 'accepted',
-      workhour: '2시간',
-    },
-    {
-      id: 2,
-      shopName: '써니 브런치 레스토랑',
-      startsAt: '2023-01-12 10:00 ~ 12:00',
-      hourlyPay: '15,000원',
-      supportStatus: 'accepted',
-      workhour: '2시간',
-    },
-    {
-      id: 3,
-      shopName: '수리 에스프레소 샵',
-      startsAt: '2023-01-12 10:00 ~ 12:00',
-      hourlyPay: '15,000원',
-      supportStatus: 'rejected',
-      workhour: '2시간',
-    },
-    {
-      id: 4,
-      shopName: '너구리네 라면집',
-      startsAt: '2023-01-12 10:00 ~ 12:00',
-      hourlyPay: '15,000원',
-      supportStatus: 'pending',
-      workhour: '2시간',
-    },
-    {
-      id: 5,
-      shopName: '초가을집',
-      startsAt: '2023-01-12 10:00 ~ 12:00',
-      hourlyPay: '15,000원',
-      supportStatus: 'pending',
-      workhour: '2시간',
-    },
-  ];
+import StatusBadge from '../Badge/StatusBadge';
 
+export interface EmployeeTableData {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: EmployeeTableItem[];
+  links: EmployeeTableLink[];
+}
+
+interface EmployeeTableItem {
+  item: EmployeeTableApplication;
+  links: EmployeeTableLink[];
+}
+
+interface EmployeeTableLink {
+  description: string;
+  href: string;
+  method: string;
+  rel: string;
+}
+
+interface EmployeeTableNoticeBase {
+  id: string;
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+  closed: boolean;
+}
+
+interface EmployeeTableNoticeDetailItem {
+  item: EmployeeTableNoticeDetail;
+  href: string;
+}
+
+interface EmployeeTableNoticeDetail extends EmployeeTableNoticeBase {}
+
+interface EmployeeTableShopData {
+  id: string;
+  name: string;
+  category: string;
+  address1: string;
+  address2: string;
+  description: string;
+  imageUrl: string;
+  originalHourlyPay: number;
+}
+
+interface EmployeeTableApplication {
+  id: string;
+  status: 'pending' | 'accepted' | 'rejected' | 'canceled';
+  createdAt: string;
+  shop: EmployeeTableShop;
+  notice: EmployeeTableNoticeDetailItem;
+}
+
+interface EmployeeTableShop {
+  item: EmployeeTableShopData;
+  href: string;
+}
+interface EmployeeTableProps {
+  data: EmployeeTableData;
+}
+
+function EmployeeTable({ data }: EmployeeTableProps) {
   const baseThStyle =
     'border-gray20 border-1px bg-red10 text-left h-40px text-12px tablet:text-14px pc:text-14px';
   const baseTdStyle =
@@ -80,33 +102,32 @@ function EmployeeTable() {
           </tr>
         </thead>
         <tbody>
-          {mockData.map(
-            (
-              { shopName, startsAt, hourlyPay, supportStatus, workhour },
-              id
-            ) => (
+          {data.items.map(({ item }) => {
+            const { id, shop, notice, status } = item;
+
+            return (
               <tr key={id}>
                 <td
                   className={`${baseTdStyle} min-w-189px tablet:min-w-[228px] pc:w-228px sticky left-0px pl-8px`}
                 >
-                  {shopName}
+                  {shop.item.name}
                 </td>
                 <td
                   className={`${baseTdStyle} min-w-162px tablet:min-w-[300px] pl-8px`}
                 >
-                  {startsAt} ({workhour})
+                  {notice.item.startsAt} ({notice.item.workhour})
                 </td>
                 <td className={`${baseTdStyle} min-w-162px pl-8px`}>
-                  {hourlyPay}
+                  {notice.item.hourlyPay}
                 </td>
                 <td
                   className={`${baseTdStyle} min-w-162px tablet:min-w-[220px] pc:w-236px pl-12px`}
                 >
-                  {supportStatus}
+                  <StatusBadge status={status} />
                 </td>
               </tr>
-            )
-          )}
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/components/Table/EmployeeTable.tsx
+++ b/src/components/Table/EmployeeTable.tsx
@@ -104,21 +104,23 @@ function EmployeeTable({ data }: EmployeeTableProps) {
         <tbody>
           {data.items.map(({ item }) => {
             const { id, shop, notice, status } = item;
+            const { name } = shop.item;
+            const { hourlyPay, workhour, startsAt } = notice.item;
 
             return (
               <tr key={id}>
                 <td
                   className={`${baseTdStyle} min-w-189px tablet:min-w-[228px] pc:w-228px sticky left-0px pl-8px`}
                 >
-                  {shop.item.name}
+                  {name}
                 </td>
                 <td
                   className={`${baseTdStyle} min-w-162px tablet:min-w-[300px] pl-8px`}
                 >
-                  {notice.item.startsAt} ({notice.item.workhour})
+                  {startsAt} ({workhour})
                 </td>
                 <td className={`${baseTdStyle} min-w-162px pl-8px`}>
-                  {notice.item.hourlyPay}
+                  {hourlyPay}
                 </td>
                 <td
                   className={`${baseTdStyle} min-w-162px tablet:min-w-[220px] pc:w-236px pl-12px`}

--- a/src/components/Table/EmployerTable.tsx
+++ b/src/components/Table/EmployerTable.tsx
@@ -1,38 +1,83 @@
-function EmployerTable() {
-  const mockData = [
-    {
-      id: 1,
-      name: '김경현',
-      description:
-        '최선을 다해 열심히 일합니다. 다수의 업무 경험을 바탕으로 확실한 일처리 보여드리겠습니다.',
-      phone: '010-1234-1234',
-      supportStatus: 'pending',
-    },
-    {
-      id: 2,
-      name: '김경현',
-      description:
-        '최선을 다해 열심히 일합니다. 다수의 업무 경험을 바탕으로 확실한 일처리 보여드리겠습니다.',
-      phone: '010-1234-1234',
-      supportStatus: 'accepted',
-    },
-    {
-      id: 3,
-      name: '김경현',
-      description:
-        '최선을 다해 열심히 일합니다. 다수의 업무 경험을 바탕으로 확실한 일처리 보여드리겠습니다.',
-      phone: '010-1234-1234',
-      supportStatus: 'rejected',
-    },
-    {
-      id: 4,
-      name: '김경현',
-      description: '최선을 다해 열심히 일합니다. ',
-      phone: '010-1234-1234',
-      supportStatus: 'canceled',
-    },
-  ];
+export interface EmployerTableData {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: EmployerTableItem[];
+  links: EmployerTableLink[];
+}
 
+interface EmployerTableItem {
+  item: EmployerTableApplication;
+  links: EmployerTableLink[];
+}
+
+interface EmployerTableLink {
+  description: string;
+  href: string;
+  method: string;
+  rel: string;
+}
+
+interface EmployerTableUser {
+  item: EmployerTableUserData;
+  href: string;
+}
+
+interface EmployerTableUserData {
+  id: string;
+  email: string;
+  type: 'employer' | 'employee';
+  name?: string; // optional
+  phone?: string; // optional
+  address?: string; // optional
+  bio?: string; // optional
+}
+
+interface EmployerTableShop {
+  item: EmployerTableShopData;
+  href: string;
+}
+
+interface EmployerTableShopData {
+  id: string;
+  name: string;
+  category: string;
+  address1: string;
+  address2: string;
+  description: string;
+  imageUrl: string;
+  originalHourlyPay: number;
+}
+
+interface EmployerTableNotice {
+  item: EmployerTableNoticeData;
+  href: string;
+}
+
+interface EmployerTableNoticeData {
+  id: string;
+  hourlyPay: number;
+  description: string;
+  startsAt: string;
+  workhour: number;
+  closed: boolean;
+}
+
+interface EmployerTableApplication {
+  id: string;
+  status: 'pending' | 'accepted' | 'rejected' | 'canceled';
+  createdAt: string;
+  user: EmployerTableUser;
+  shop: EmployerTableShop;
+  notice: EmployerTableNotice;
+}
+
+interface EmployerTableProps {
+  data: EmployerTableData;
+}
+
+function EmployerTable({ data }: EmployerTableProps) {
   const baseThStyle = `border-gray20 border-1px bg-red10 text-left h-40px text-12px tablet:text-14px pc:text-14px`;
   const baseTdStyle = `border-gray20 border-1px text-14px tablet:text-16px pc:text-16px bg-white`;
 
@@ -67,28 +112,34 @@ function EmployerTable() {
           </tr>
         </thead>
         <tbody>
-          {mockData.map(({ name, description, phone, supportStatus }, id) => (
-            <tr key={id}>
-              <td
-                className={`${baseTdStyle} min-w-189px tablet:min-w-[228px] pc:w-228px h-46px sticky left-0 pl-8px z-10`}
-              >
-                {name}
-              </td>
-              <td
-                className={`${baseTdStyle} min-w-262px tablet:min-w-[300px] pc:w-300px h-46px tablet:h-91px pc:h-91px pl-8px tablet:py-20px tablet:px-16px pc:py-20px pc:px-16px`}
-              >
-                <p className="line-clamp-2">{description}</p>
-              </td>
-              <td className={`${baseTdStyle} min-w-162px h-46px pl-8px`}>
-                {phone}
-              </td>
-              <td
-                className={`${baseTdStyle} min-w-162px tablet:min-w-[220px] pc:w-236px h-46px pl-12px`}
-              >
-                {supportStatus}
-              </td>
-            </tr>
-          ))}
+          {data.items.map(({ item }) => {
+            const { id, status, user, notice } = item;
+            const { name, phone } = user.item;
+            const { description } = notice.item;
+
+            return (
+              <tr key={id}>
+                <td
+                  className={`${baseTdStyle} min-w-189px tablet:min-w-[228px] pc:w-228px h-46px sticky left-0 pl-8px z-10`}
+                >
+                  {name}
+                </td>
+                <td
+                  className={`${baseTdStyle} min-w-262px tablet:min-w-[300px] pc:w-300px h-46px tablet:h-91px pc:h-91px pl-8px tablet:py-20px tablet:px-16px pc:py-20px pc:px-16px`}
+                >
+                  <p className="line-clamp-2">{description}</p>
+                </td>
+                <td className={`${baseTdStyle} min-w-162px h-46px pl-8px`}>
+                  {phone}
+                </td>
+                <td
+                  className={`${baseTdStyle} min-w-162px tablet:min-w-[220px] pc:w-236px h-46px pl-12px`}
+                >
+                  {status}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/constants/statusMap.ts
+++ b/src/constants/statusMap.ts
@@ -14,4 +14,9 @@ export const STATUS_MAP = {
     textColor: 'text-red40',
     text: '거절',
   },
+  canceled: {
+    backgroundColor: 'bg-gray10',
+    textColor: 'text-gray40',
+    text: '취소',
+  },
 } as const;

--- a/src/utils/api/applicationAPI.ts
+++ b/src/utils/api/applicationAPI.ts
@@ -87,10 +87,17 @@ const applicationAPI = {
       offset,
       limit,
     };
+    // 로컬스토리지의 토큰을 사용하여 인증하는 경우
+    // const headers = {
+    //   Authorization: `Bearer ${localStorage.getItem('token')}`,
+    // };
     try {
       const response = await axiosInstance.get(
         `/users/${user_id}/applications`,
-        { params }
+        {
+          params,
+          // headers
+        }
       );
       return response.data;
     } catch (error) {


### PR DESCRIPTION
## #️⃣연관된 이슈
DD-48-Table-Connect-to-the-API

## 📝작업 내용

- EmployerTable, EmployeeTable 각각 데이터 연결
- 필요한 데이터를 연결했지만 아직 타입 통합은 안됐습니다.
- 뱃지와 버튼 컴포넌트 넣고 내부의 데이터의 표기형식은 유틸 함수 적용하는 작업은 다음 브랜치에서 진행하겠습니다.

### 스크린샷 (선택)
![테이블 데이터 연결1](https://github.com/sprint6-team12/the-julge/assets/97877328/97437143-5138-4fcf-a527-8d7e2dd80987)
![테이블 데이터 연결2](https://github.com/sprint6-team12/the-julge/assets/97877328/a11350f2-1718-40b8-89ce-a5ffdcf7f1cd)

