### PR TITLE
💄style: 데스크탑일때 뱃지 디자인 변경 (제안)

### DIFF
--- a/src/components/Post/PostCard.tsx
+++ b/src/components/Post/PostCard.tsx
@@ -52,11 +52,15 @@ export default function PostCard({
       </div>
       <div className="flex justify-between flex-col pt-16px gap-0px tablet:flex-row pc:flex-row mt-auto">
         <Post.Title text={formattedPay} className={`shrink-0`} />
-        <Post.IncreaseRateBadge
-          hourlyPay={hourlyPay}
-          originalHourlyPay={originalHourlyPay}
-          bgNone={bgNone}
-        />
+        <div
+          className={`pc:absolute pc:top-24px pc:right-22px ${currentPostState !== 'open' ? 'pc:hidden' : ''}`}
+        >
+          <Post.IncreaseRateBadge
+            hourlyPay={hourlyPay}
+            originalHourlyPay={originalHourlyPay}
+            bgNone={bgNone}
+          />
+        </div>
       </div>
     </Post.Wrapper>
   );

--- a/src/components/pageComponents/NoticeDetail/NoticeDetailCard.tsx
+++ b/src/components/pageComponents/NoticeDetail/NoticeDetailCard.tsx
@@ -49,12 +49,10 @@ function NoticeDetailCard({ data }: NoticeDetailCardProps) {
             text={formattedPay}
             className="shrink-0 text-24px tablet:text-28px"
           />
-          {currentNoticeState !== 'closed' && (
-            <Post.IncreaseRateBadge
-              hourlyPay={hourlyPay}
-              originalHourlyPay={originalHourlyPay}
-            />
-          )}
+          <Post.IncreaseRateBadge
+            hourlyPay={hourlyPay}
+            originalHourlyPay={originalHourlyPay}
+          />
         </div>
         <Post.WorkSchedule
           startsAt={startsAt}

--- a/src/components/pageComponents/NoticeDetail/NoticeDetailCard.tsx
+++ b/src/components/pageComponents/NoticeDetail/NoticeDetailCard.tsx
@@ -44,7 +44,9 @@ function NoticeDetailCard({ data }: NoticeDetailCardProps) {
       />
       <div className={`flex flex-col gap-12px pc:w-[70%]`}>
         <Post.TitleBadge badgeText="시급" className="-mb-8px mt-8px" />
-        <div className="flex gap-8px items-center [&>_span]:shrink-0">
+        <div
+          className={`flex gap-8px items-center [&>_span]:shrink-0 ${currentNoticeState !== 'open' ? '[&>_span]:bg-gray30' : ''}`}
+        >
           <Post.Title
             text={formattedPay}
             className="shrink-0 text-24px tablet:text-28px"


### PR DESCRIPTION
## #️⃣연관된 이슈

> [#DD72](https://dodobirdy.atlassian.net/browse/DD-72?atlOrigin=eyJpIjoiZWY5NzFhODdkMDVlNDUzMjk5NTdjYWE5YmFiMGNlNzciLCJwIjoiaiJ9)
자세한 내용이 담긴 지라 이슈입니다 추가 의견있으시면 이슈에 남겨주세요!!

## 📝작업 내용

> 이슈대로 작업해봤고 멘토님 피드백 + 다른 팀원분들 의견받아서 결정나면 머지 ( +수정 ) 하겠습니다! 

### 스크린샷 (선택)

#### **`수정전 (마감된 공고 상세에는 인상%뱃지 안보이는 상황입니답)`**
<img width="777" alt="image" src="https://github.com/sprint6-team12/the-julge/assets/154623483/2aac7658-6e6b-4d73-9012-e2d8bf6d93fb">

#### **`수정후 (닫힌 공고일때도 공고상세페이지에서 뱃지 확인가능 + pc일때 포스트카드 컴포넌트 뱃지위치변경)`**
<img width="773" alt="image" src="https://github.com/sprint6-team12/the-julge/assets/154623483/17ceb242-0014-46db-8035-757fcfb502c3">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
