### PR TITLE
♻️refactor: 로그인 회원가입 popup, recoil 관련 수정

### DIFF
--- a/src/components/Gnb/GnbButton.tsx
+++ b/src/components/Gnb/GnbButton.tsx
@@ -1,12 +1,10 @@
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import GnbUiButton from '@/components/Gnb/GnbUiButton';
 import ModalCustom from '@/components/Modal/ModalCustom';
 import LoginSignUp from '@/components/pageComponents/LoginSignUp/LoginSignUp';
 import { useAuth } from '@/hooks/useAuth';
 import useModal from '@/hooks/useModal';
-import userAPI from '@/lib/api/userAPI';
 import { IconCloseBlack } from '@/lib/utils/Icons';
 import { userState } from '@/recoil/atoms/AuthAtom';
 
@@ -59,23 +57,13 @@ const SpecialModal = ({
 
 export default function GnbButton({ userType, onClick }: GnbButtonProps) {
   const { openModal } = useModal();
-  const { userId, type, shopId } = useRecoilValue(userState);
+  const { userId, shopId } = useRecoilValue(userState);
   const router = useRouter();
   const { setUser } = useAuth();
-  const setAuthState = useSetRecoilState(userState);
 
   const openLoginModal = (isLogin: boolean) => {
     openModal('LoginSignUpModal', SpecialModal, { isLogin });
   };
-
-  useEffect(() => {
-    if (userId) {
-      const getUserShopId = async (userId: string, type: string) => {
-        await userAPI.getUserData(userId, type, setAuthState);
-      };
-      getUserShopId(userId, type);
-    }
-  }, []);
 
   const handleGnbButtonsClick = (buttonId: string) => {
     if (userType === 'guest' || userType === undefined) {

--- a/src/components/Gnb/GnbButton.tsx
+++ b/src/components/Gnb/GnbButton.tsx
@@ -37,11 +37,15 @@ const EMPLOYEE_BUTTONS: GnbButtonType[] = [
 const SpecialModal = ({
   onClose,
   isLogin = false,
+  autoClose = true,
 }: {
   onClose?: () => void;
   isLogin?: boolean;
+  autoClose?: boolean;
 }) => (
   <ModalCustom
+    autoClose={autoClose}
+    onClose={onClose}
     content={
       <div className="relative min-w-[480px] border rounded-20px border-gray20 bg-white">
         <LoginSignUp isLogin={isLogin} onClose={onClose} />

--- a/src/components/pageComponents/LoginSignUp/SignInForm.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignInForm.tsx
@@ -31,7 +31,12 @@ export default function SignInForm({ onClose }: { onClose?: () => void }) {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!errors.loginEmail && !errors.loginPassWord) {
+    if (
+      !errors.loginEmail &&
+      !errors.loginPassWord &&
+      formData.loginEmail !== '' &&
+      formData.loginPassWord !== ''
+    ) {
       try {
         await authenticationAPI.postToken(
           {

--- a/src/components/pageComponents/LoginSignUp/SignInForm.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignInForm.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import Button from '@/components/Button/Button';
+import usePopup from '@/hooks/usePopup';
 import authenticationAPI from '@/lib/api/authenticationAPI';
 import userAPI from '@/lib/api/userAPI';
 import { SignInValidate } from '@/lib/utils/validation';
-import { userState } from '@/recoil/atoms/AuthAtom'; // 경로 확인
+import { userState } from '@/recoil/atoms/AuthAtom';
 import InputComponent from './InputComponent';
 
 export default function SignInForm({ onClose }: { onClose?: () => void }) {
@@ -15,12 +16,17 @@ export default function SignInForm({ onClose }: { onClose?: () => void }) {
   const [errors, setErrors] = useState({ loginEmail: '', loginPassWord: '' });
   const setAuthState = useSetRecoilState(userState);
   const { userId, type } = useRecoilValue(userState);
+  const { openPopup } = usePopup();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
     const errorMessage = SignInValidate(name, value);
     setErrors((prevErrors) => ({ ...prevErrors, [name]: errorMessage }));
     setFormData((prevFormData) => ({ ...prevFormData, [name]: value }));
+  };
+
+  const openTostPopup = (errors: any) => {
+    openPopup('loginErrorMessage', errors.message, 2500);
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -39,7 +45,7 @@ export default function SignInForm({ onClose }: { onClose?: () => void }) {
           onClose();
         }
       } catch (error) {
-        alert(error);
+        openTostPopup(error);
       }
     }
   };

--- a/src/components/pageComponents/LoginSignUp/SignUpForm.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignUpForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '@/components/Button/Button';
+import usePopup from '@/hooks/usePopup';
 import userAPI from '@/lib/api/userAPI';
 import { SignUpValidate } from '@/lib/utils/validation';
 import InputComponent from './InputComponent';
@@ -17,12 +18,17 @@ const SignUpForm = ({ onSignUpSuccess }: { onSignUpSuccess: () => void }) => {
     signUpPassword: '',
     signUpPasswordConfirm: '',
   });
+  const { openPopup } = usePopup();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
     const errorMessage = SignUpValidate(name, value, formData);
     setErrors((prevErrors) => ({ ...prevErrors, [name]: errorMessage }));
     setFormData((prevFormData) => ({ ...prevFormData, [name]: value }));
+  };
+
+  const openTostPopup = (errors: any) => {
+    openPopup('signUpErrorMessage', errors.message, 2500);
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -41,7 +47,7 @@ const SignUpForm = ({ onSignUpSuccess }: { onSignUpSuccess: () => void }) => {
         alert('회원가입이 완료되었습니다.');
         onSignUpSuccess();
       } catch (error) {
-        alert(error);
+        openTostPopup(error);
       }
     }
   };

--- a/src/components/pageComponents/LoginSignUp/SignUpForm.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignUpForm.tsx
@@ -36,7 +36,10 @@ const SignUpForm = ({ onSignUpSuccess }: { onSignUpSuccess: () => void }) => {
     if (
       !errors.signUpEmail &&
       !errors.signUpPassword &&
-      !errors.signUpPasswordConfirm
+      !errors.signUpPasswordConfirm &&
+      formData.signUpEmail !== '' &&
+      formData.signUpPassword !== '' &&
+      formData.signUpPasswordConfirm !== ''
     ) {
       try {
         await userAPI.postUserData({

--- a/src/components/pageComponents/LoginSignUp/SignUpForm.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignUpForm.tsx
@@ -48,6 +48,12 @@ const SignUpForm = ({ onSignUpSuccess }: { onSignUpSuccess: () => void }) => {
           type: userType,
         });
         alert('회원가입이 완료되었습니다.');
+        setFormData(() => ({
+          signUpEmail: '',
+          signUpPassword: '',
+          signUpPasswordConfirm: '',
+        }));
+        setUserType('employee');
         onSignUpSuccess();
       } catch (error) {
         openTostPopup(error);

--- a/src/lib/api/ApiError.ts
+++ b/src/lib/api/ApiError.ts
@@ -6,7 +6,7 @@ class APIError extends Error {
     public status: number
   ) {
     super(message);
-    this.name = 'APIError';
+    this.name = '';
   }
 }
 

--- a/src/lib/api/userAPI.ts
+++ b/src/lib/api/userAPI.ts
@@ -26,8 +26,8 @@ const userAPI = {
 
       if (type == 'employer') {
         const shopId = response?.data?.item?.shop?.item?.id;
-        const address = response?.data?.item?.shop?.items?.address1;
-        const DetailAddress = response?.data?.item?.shop?.items?.address2;
+        const address = response?.data?.item?.shop?.item?.address1;
+        const DetailAddress = response?.data?.item?.shop?.item?.address2;
         setAuthState((prevState: User) => ({
           ...prevState,
           shopId: shopId,


### PR DESCRIPTION
## #️⃣연관된 이슈

> Dd 98 refactor login sign up alert

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- GnbButton.tsx 에서 저장하던 레코일 shopid가 로그인 하고나서 새로고침을 해야 저장되는 이슈가 있어서 로그인할때 같이 저장하도록 수정했습니다.

![image](https://github.com/sprint6-team12/the-julge/assets/162148781/fc0d8286-d2f2-4237-a415-5d41496392ab)
- items 오타가 있어서 address가 저장이 안되더라구요 수정했습니다 !
- 로그인 회원가입 컨테이너 백그라운드 클릭시 닫히게 바꿔주신거 적용했습니다.
- 로그인 회원가입 alert로 나오던 APIError: 지우고 popup으로 나오도록 바꿨습니다.
이유
( 사진에 빨간, 파란 테두리는 이해를 위해서 그린거에요 !!)
![image](https://github.com/sprint6-team12/the-julge/assets/162148781/3aa58a51-c781-4d2b-a717-8bc54fcd2222)
빨간 모달창의 백그라운드가 파란 로그인 회원가입 컨테이너 이길 바랬지만 부모 modal-wrapper가 같은 레벨이라 파란 컨테이너 외부를 클릭해야 모달창, 로그인 회원가입 컨테이너가 순서대로 닫히는 이슈가 있어서 popup로 변경했습니다.
- 로그인, 회원가입 컨테이너에 처음 들어갔을때 바로 submit을 하면 errors state에 에러가 없는 상태라 submit이 작동하던 이슈를 해결했습니다.
- 회원가입에 성공하면 인풋 벨류들을 초기화하도록 변경했습니다.


### 스크린샷 (선택)

## app 컴포넌트에 popupwrapper이 있을때
![image](https://github.com/sprint6-team12/the-julge/assets/162148781/3b99d566-c755-4468-b6c0-28f0593e0f87)

## 로그인 회원가입 컴포넌트에 popupwrapper이 있을때
![image](https://github.com/sprint6-team12/the-julge/assets/162148781/6036287e-1084-4dbc-a8bd-cdc3203d4156)

위에사진은 z-index를 수정해서 로그인회원가입 컴포넌트보다 상위에 있도록 지정하면 색상은 돌아옵니다!! 하지만 이미 popup을 사용하고있는 컴포넌트들이 있어서 popupwrapper을 사용하는 컴포넌트에 두는 방식으로 변경하기엔 애매할것 같아 냅두었습니다 차차 시간이 남을때 얘기해보고 바꿔보면 좋을것 같습니다.


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
