### PR TITLE
feat: 홈 이동 시 검색 초기화 기능 추가 (#103)

### DIFF
--- a/src/components/Gnb/SearchBar.tsx
+++ b/src/components/Gnb/SearchBar.tsx
@@ -7,12 +7,11 @@ import keywordDataState from '@/recoil/atoms/searchAtom';
 import searchResultState from '@/recoil/atoms/SearchResultAtom';
 
 export default function SearchBar() {
-  const [searchInput, setSearchInput] = useState(''); // 검색창에 입력된 값, 검색창에 보여주거나 api keyword에 전달
-  const setKeyword = useSetRecoilState(keywordDataState); // 검색창에 입력된 값을 전역 상태로 만든다.
-  const setSearchResult = useSetRecoilState(searchResultState); // api 함수로 반환된 결과를 전역 상태로 만든다
+  const [searchInput, setSearchInput] = useState('');
+  const setKeyword = useSetRecoilState(keywordDataState);
+  const setSearchResult = useSetRecoilState(searchResultState);
   const { handleSearch } = useNoticeList(INITIAL_NOTICE_DATA);
 
-  // recoil atoms에 있는 전역상태 값 변경
   const setSearchAtoms = useCallback(
     (keyword: string, results: NoticeListResponseData) => {
       setKeyword(keyword);
@@ -21,27 +20,22 @@ export default function SearchBar() {
     [setKeyword, setSearchResult]
   );
 
-  // 검색 실행 함수
   const initiateSearch = async () => {
     const results = await handleSearch(searchInput);
     setSearchAtoms(searchInput, results);
   };
 
-  // 검색 초기화 함수
   const resetSearchResult = async () => {
-    // 검색어 없는 상태의 리스트를 받아옴
     const results = await handleSearch('');
     setSearchAtoms('', results);
     setSearchInput('');
   };
 
-  // 검색창의 이벤트 감지
   const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     setSearchInput(value);
   };
 
-  // 검색창의 키입력 감지
   const handleKeyPress = async (
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
@@ -71,13 +65,13 @@ export default function SearchBar() {
       {searchInput && (
         <IconCloseBlack
           className="absolute right-10px"
-          onClick={() => resetSearchResult()}
+          onClick={resetSearchResult}
         />
       )}
       {searchInput && (
         <IconCloseBlack
           className="absolute right-10px"
-          onClick={() => resetSearchResult()}
+          onClick={resetSearchResult}
         />
       )}
     </div>

--- a/src/hooks/useResetSearchOnHome.ts
+++ b/src/hooks/useResetSearchOnHome.ts
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import keywordDataState from '@/recoil/atoms/searchAtom';
+import searchResultState from '@/recoil/atoms/SearchResultAtom';
+
+export function useResetSearchOnHome(initialData: NoticeListResponseData) {
+  const setKeyword = useSetRecoilState(keywordDataState);
+  const setSearchResult = useSetRecoilState(searchResultState);
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      if (url === '/') {
+        setKeyword('');
+        setSearchResult(initialData);
+      }
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events, setKeyword, setSearchResult, initialData]);
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,12 +3,14 @@ import { useRecoilValue } from 'recoil';
 import CustomizedNoticeList from '@/components/pageComponents/NoticeList/CustomizedNoticeList';
 import NoticeListView from '@/components/pageComponents/NoticeList/NoticeListView';
 import SearchPage from '@/components/pageComponents/SearchPage/SearchPage';
+import { useResetSearchOnHome } from '@/hooks/useResetSearchOnHome';
 import noticeAPI from '@/lib/api/noticeAPI';
 import keywordDataState from '@/recoil/atoms/searchAtom';
 
 export default function Home(data: NoticeListResponseData) {
   const keyword = useRecoilValue(keywordDataState);
   const isSearchData = keyword !== '';
+  useResetSearchOnHome(data);
 
   if (isSearchData) return <SearchPage />;
 
@@ -21,7 +23,7 @@ export default function Home(data: NoticeListResponseData) {
 }
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const data = await noticeAPI.getNoticeList({ offset: 0, limit: 6 });
+  const data = await noticeAPI.getNoticeList({ limit: 6 });
 
   return {
     props: data,


### PR DESCRIPTION
## #️⃣연관된 이슈
DD-103-feat-route-change-handler-hook
(#103)

## 📝작업 내용

- 기존 홈 이동 후에도 검색 내용이 남아있어서 컴포넌트가 안사라지는 문제 해결
- 라우터 이벤트리스너를 사용해서 홈 이동을 감지하여 검색 초기화 로직 실행

