### PR TITLE
💄style: LoginSignUp 모바일 디자인 변경

### DIFF
--- a/src/components/Gnb/GnbButton.tsx
+++ b/src/components/Gnb/GnbButton.tsx
@@ -47,10 +47,10 @@ const SpecialModal = ({
     autoClose={autoClose}
     onClose={onClose}
     content={
-      <div className="relative min-w-[480px] border rounded-20px border-gray20 bg-white">
+      <div className="relative bg-white border rounded-20px border-gray20">
         <LoginSignUp isLogin={isLogin} onClose={onClose} />
         <IconCloseBlack
-          className="absolute top-20px right-20px cursor-pointer"
+          className="absolute cursor-pointer top-20px right-20px"
           onClick={onClose}
           aria-label="닫기"
         />

--- a/src/components/pageComponents/LoginSignUp/LoginSignUp.tsx
+++ b/src/components/pageComponents/LoginSignUp/LoginSignUp.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import useMediaQuery from '@/lib/utils/useMediaQuery';
 import SignInFormContainer from './SignInFormContainer';
 import SignUpFormContainer from './SignUpFormContainer';
 import ToggleContainer from './ToggleContainer';
@@ -11,21 +12,42 @@ export default function LoginSignUp({
   onClose?: () => void;
 }) {
   const [isSignUp, setIsSignUp] = useState(isLogin);
+  const { isMobile } = useMediaQuery();
 
   const toggleSignUp = () => {
     setIsSignUp((prev) => !prev);
   };
 
   return (
-    <div className="flex-center">
-      <div className="relative flex justify-between tablet:w-[700px] pc:w-[900px] mx-auto overflow-x-hidden rounded-24px">
-        <SignInFormContainer isSignUp={isSignUp} onClose={onClose} />
+    <div className={`flex-center${isMobile ? ' flex-col' : ''}`}>
+      <div
+        className={`${isMobile ? 'h-[605px] w-320px' : 'relative flex justify-between tablet:w-[700px] pc:w-[900px] mx-auto overflow-x-hidden rounded-24px'}`}
+      >
+        <SignInFormContainer
+          isSignUp={isSignUp}
+          onClose={onClose}
+          isMobile={isMobile}
+        />
         <SignUpFormContainer
           isSignUp={isSignUp}
           onSignUpSuccess={toggleSignUp}
+          isMobile={isMobile}
         />
-        <ToggleContainer isSignUp={isSignUp} onToggle={toggleSignUp} />
+        {!isMobile && (
+          <ToggleContainer
+            isSignUp={isSignUp}
+            onToggle={toggleSignUp}
+            isMobile={isMobile}
+          />
+        )}
       </div>
+      {isMobile && (
+        <ToggleContainer
+          isSignUp={isSignUp}
+          onToggle={toggleSignUp}
+          isMobile={isMobile}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/pageComponents/LoginSignUp/SignInForm.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignInForm.tsx
@@ -86,7 +86,7 @@ export default function SignInForm({ onClose }: { onClose?: () => void }) {
         errorMessage={errors.loginPassWord}
       />
       <Button className="w-full button_medium_active" type="submit">
-        로그인 하기
+        로그인
       </Button>
     </form>
   );

--- a/src/components/pageComponents/LoginSignUp/SignInFormContainer.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignInFormContainer.tsx
@@ -3,13 +3,15 @@ import SignInForm from './SignInForm';
 export default function SignInFormContainer({
   isSignUp,
   onClose,
+  isMobile,
 }: {
   isSignUp: boolean;
+  isMobile: boolean;
   onClose?: () => void;
 }) {
   return (
     <div
-      className={`flex-center w-full p-10 transition-transform duration-500 ease-in-out ${isSignUp ? '-translate-x-full collapse' : ''}`}
+      className={`flex-center w-full p-10 transition-transform ease-in-out${isMobile ? ' duration-300' : ' duration-500'}${isMobile ? (isSignUp ? ' scale-0' : ' scale-1') : isSignUp ? ' -translate-x-full collapse' : ''}`}
     >
       <SignInForm onClose={onClose} />
     </div>

--- a/src/components/pageComponents/LoginSignUp/SignUpFormContainer.tsx
+++ b/src/components/pageComponents/LoginSignUp/SignUpFormContainer.tsx
@@ -3,13 +3,15 @@ import SignUpForm from './SignUpForm';
 export default function SignUpFormContainer({
   isSignUp,
   onSignUpSuccess,
+  isMobile,
 }: {
   isSignUp: boolean;
+  isMobile: boolean;
   onSignUpSuccess: () => void;
 }) {
   return (
     <div
-      className={`flex-center w-full p-10 transition-transform duration-500 ease-in-out ${isSignUp ? '' : 'translate-x-full collapse'}`}
+      className={`flex-center w-full p-10 transition-transform ease-in-out${isMobile ? ' duration-300' : ' duration-500'}${isMobile ? ' -translate-y-[67%]' : ''}${isMobile ? (isSignUp ? ' scale-1' : ' scale-0') : isSignUp ? '' : ' translate-x-full collapse'}`}
     >
       <SignUpForm onSignUpSuccess={onSignUpSuccess} />
     </div>

--- a/src/components/pageComponents/LoginSignUp/ToggleContainer.tsx
+++ b/src/components/pageComponents/LoginSignUp/ToggleContainer.tsx
@@ -5,6 +5,7 @@ import Logo from '/public/images/logo.png';
 type ToggleContainerProps = {
   isSignUp: boolean;
   onToggle: () => void;
+  isMobile: boolean;
 };
 
 const signUp = {
@@ -19,8 +20,25 @@ const signIn = {
   sign: '회원가입',
 };
 
-const ToggleContainer = ({ isSignUp, onToggle }: ToggleContainerProps) => {
+const ToggleContainer = ({
+  isSignUp,
+  onToggle,
+  isMobile,
+}: ToggleContainerProps) => {
   const content = isSignUp ? signUp : signIn;
+
+  const ToggleButton = () => (
+    <Button
+      className={`button_medium_active${isMobile ? ' mb-20px' : ''}`}
+      onClick={onToggle}
+    >
+      {content.sign}
+    </Button>
+  );
+
+  if (isMobile) {
+    return ToggleButton();
+  }
 
   return (
     <div
@@ -30,11 +48,9 @@ const ToggleContainer = ({ isSignUp, onToggle }: ToggleContainerProps) => {
     >
       <>
         <Image src={Logo} className="mb-16px" alt="더줄게 로고" />
-        <h1 className="mb-16px text-xl font-bold">{content.title}</h1>
+        <h1 className="text-xl font-bold mb-16px">{content.title}</h1>
         <p className="mb-32px">{content.text}</p>
-        <Button className="button_medium_active" onClick={onToggle}>
-          {content.sign}
-        </Button>
+        {ToggleButton()}
       </>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> DD-106-style: LoginSingup 모바일 디자인 변경

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

https://github.com/sprint6-team12/the-julge/assets/162148781/46b31227-5845-46c3-acb1-76c815a6c2e0

모바일 <-> 태블릿 화면전환시 효과는 각각의 상태일때 부모태그 클래스가 달라서 그래요 ㅠㅠ
제실력으로 저거까지 보완할 방법을 모르겠긴 한데 진짜 모바일이나 진짜 태블릿에서 서로 바뀔일이 없을것 같아서 냅두었습니다 !

```js
// LoginSignUp.tsx
return (
    <div className={`flex-center${isMobile ? ' flex-col' : ''}`}>
      <div
        className={`${isMobile ? 'h-[605px] w-320px' : 'relative flex justify-between tablet:w-[700px] pc:w-[900px] mx-auto overflow-x-hidden rounded-24px'}`}
      >
        ...
        {!isMobile && (
          <ToggleContainer
            isSignUp={isSignUp}
            onToggle={toggleSignUp}
            isMobile={isMobile}
          />
        )}
      </div>
      {isMobile && (
        <ToggleContainer
          isSignUp={isSignUp}
          onToggle={toggleSignUp}
          isMobile={isMobile}
        />
      )}
    </div>
  );
```
뭔가 지저분한테 모바일일때와 아닐때 부모 div태그 css가 다르다보니 ToggleContainer 위치도 달라져야돼서 이방법밖엔 생각이 안나네요.. flex 상태일때 하위애들을 어떻게 숨기고 다시보여줄지가 애매해서 모바일일땐 flex를 안썼습니다
뭔가 좋은 방법이 있을까요 ?

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
