### PR TITLE
feat: 검색 결과 컴포넌트에서 페이지로 변경, 페이지 이동 시 검색창 값 초기화

### DIFF
--- a/src/components/Gnb/SearchBar.tsx
+++ b/src/components/Gnb/SearchBar.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { INITIAL_NOTICE_DATA } from '@/constants/initialNoticeData';
 import useNoticeList from '@/hooks/useNoticeList';
@@ -7,10 +8,17 @@ import keywordDataState from '@/recoil/atoms/searchAtom';
 import searchResultState from '@/recoil/atoms/SearchResultAtom';
 
 export default function SearchBar() {
+  const router = useRouter();
   const [searchInput, setSearchInput] = useState('');
   const setKeyword = useSetRecoilState(keywordDataState);
   const setSearchResult = useSetRecoilState(searchResultState);
   const { handleSearch } = useNoticeList(INITIAL_NOTICE_DATA);
+
+  useEffect(() => {
+    if (router.pathname !== '/search') {
+      setSearchInput('');
+    }
+  }, [router.pathname]);
 
   const setSearchAtoms = useCallback(
     (keyword: string, results: NoticeListResponseData) => {
@@ -23,12 +31,14 @@ export default function SearchBar() {
   const initiateSearch = async () => {
     const results = await handleSearch(searchInput);
     setSearchAtoms(searchInput, results);
+    router.push(`/search?q=${searchInput}`);
   };
 
   const resetSearchResult = async () => {
     const results = await handleSearch('');
     setSearchAtoms('', results);
     setSearchInput('');
+    router.push('/');
   };
 
   const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,31 +1,11 @@
-//index.tsx
 import { GetServerSideProps } from 'next';
-import { useEffect, useState, useTransition } from 'react';
-import { useRecoilValue } from 'recoil';
-import Loading from '@/components/pageComponents/Loading/Loading';
 import CustomizedNoticeList from '@/components/pageComponents/NoticeList/CustomizedNoticeList';
 import NoticeListView from '@/components/pageComponents/NoticeList/NoticeListView';
-import SearchPage from '@/components/pageComponents/SearchPage/SearchPage';
 import { useResetSearchOnHome } from '@/hooks/useResetSearchOnHome';
 import noticeAPI from '@/lib/api/noticeAPI';
-import keywordDataState from '@/recoil/atoms/searchAtom';
 
 export default function Home(data: NoticeListResponseData) {
-  const keyword = useRecoilValue(keywordDataState);
-  const [isSearchData, setIsSearchData] = useState(false);
-  const [isPending, startTransition] = useTransition();
-
   useResetSearchOnHome(data);
-
-  useEffect(() => {
-    startTransition(() => {
-      setIsSearchData(keyword !== '');
-    });
-  }, [keyword]);
-
-  if (isPending) return <Loading />;
-
-  if (isSearchData) return <SearchPage />;
 
   return (
     <>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,0 +1,43 @@
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
+import Nothing from '@/../../public/images/arbaba-nothing.png';
+import NoticeListView from '@/components/pageComponents/NoticeList/NoticeListView';
+import searchResultState from '@/recoil/atoms/SearchResultAtom';
+
+function Search() {
+  const router = useRouter();
+  const queryQ = router.query.q as string;
+  const searchResults = useRecoilValue(searchResultState);
+
+  const hasResults = useMemo(() => {
+    return searchResults?.items?.length > 0;
+  }, [searchResults]);
+
+  if (!hasResults) {
+    return (
+      <div className="mx-auto w-fit h-340px text-20px tablet:text-28px pc:text-34px mb-80px flex-center flex-col">
+        <Image src={Nothing} alt="검색결과없음" height={60} width={300} />
+        <div>
+          <span className="text-red40">{queryQ}</span>에 해당하는 목록이
+          없습니다.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <NoticeListView
+      key={queryQ}
+      initialData={searchResults}
+      title={
+        <>
+          <span className="text-red40">{queryQ}</span>에 대한 공고 목록
+        </>
+      }
+    />
+  );
+}
+
+export default Search;


### PR DESCRIPTION

## #️⃣연관된 이슈
DD-128-feat-enhance-search-page-functionality
#128

## 📝작업 내용
- 검색 결과를 페이지로 만들기
/search 경로에 페이지를 만들어 검색 결과를 보여준다.
useRouter를 사용해서 히스토리를 만든다.
- 검색창 페이지 이동 시 초기화

### 스크린샷 (선택)
변경 전
![홈화면이동문제](https://github.com/user-attachments/assets/816df745-72a9-4492-bafe-7d61f0559de2)

변경 후
![검색페이지개선](https://github.com/user-attachments/assets/f40bc90f-4c19-4051-a200-7e78242687f5)


